### PR TITLE
include high quality url in order metadata

### DIFF
--- a/src/hooks/useAssets.tsx
+++ b/src/hooks/useAssets.tsx
@@ -67,7 +67,7 @@ const useAssets: (address: string) => AssetsConfig = (address: string) => {
   const [didInitialFetch, setDidInitialFetch] = useState<boolean>(false);
 
   if (process.env.NEXT_PUBLIC_DEV_MODE) {
-    address = "0xdb21617ddcceed28568af2f8fc6549887712a011";
+    address = "0x694e64d4ad77e0c234b7b1c55ac40302ad86ce3f";
   }
 
   // TODO: we can optimize this with server side rendering if it becomes too slow.

--- a/src/hooks/useCart.tsx
+++ b/src/hooks/useCart.tsx
@@ -16,7 +16,9 @@ export type ItemConfiguration = {
 
 export type CartItem = {
   name: string;
-  uri: string;
+  basic_uri: string;
+  original_uri: string;
+  preview_uri: string;
   config: ItemConfiguration;
 };
 

--- a/src/pages/customize.tsx
+++ b/src/pages/customize.tsx
@@ -72,7 +72,7 @@ export default function Customize(props: CustomizePageProps) {
         <title>Print.Fi</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <Header subPage="print"/>
+      <Header subPage="print" />
       <main className={styles.main}>
         {item == null ? (
           <section {...containerProps}>{indicatorEl}</section>
@@ -106,7 +106,9 @@ export default function Customize(props: CustomizePageProps) {
                 onClick={() => {
                   addToCart({
                     name: item.name,
-                    uri: item.image_thumbnail_url,
+                    basic_uri: item.image_url,
+                    preview_uri: item.image_thumbnail_url,
+                    original_uri: item.image_original_url,
                     config: itemConfiguration,
                   });
                   router.push("/review");

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -78,7 +78,7 @@ export default function Review(props: ReviewPageProps) {
                       {rowItem(
                         <TokenCard
                           name={item.name}
-                          uri={item.uri}
+                          uri={item.preview_uri}
                           height={100}
                           width={70}
                         />


### PR DESCRIPTION
noticed that the api is already returning higher (and lower) quality images. with this change we'll use the lower-res images for smaller sizes previews on the review screen, and include the high res ones in the order metadata sent to backend