### PR TITLE
Toby/aspect ratios

### DIFF
--- a/src/components/CartDetailsTable.tsx
+++ b/src/components/CartDetailsTable.tsx
@@ -47,7 +47,6 @@ export default function CartDetailsTable(props: CartDetailsTableProps) {
                 <TokenCard
                   name={item.name}
                   uri={item.preview_uri}
-                  height={100}
                   width={70}
                 />
               )}

--- a/src/components/OptionRow.tsx
+++ b/src/components/OptionRow.tsx
@@ -19,6 +19,7 @@ const OptionRow = (props: OptionRowProps) => {
         {props.options.map((option) => {
           return (
             <Button
+              key={option}
               style={{ marginRight: "1rem", minWidth: "8rem" }}
               color="primary"
               disabled={props.selection === option}

--- a/src/components/TokenCard.tsx
+++ b/src/components/TokenCard.tsx
@@ -1,7 +1,6 @@
 import styles from "../styles/Home.module.css";
 import * as React from "react";
 import Link from "next/link";
-import Image from "next/image";
 import { UrlObject } from "url";
 import classNames from "classnames";
 import { isNullOrEmpty } from "../utils/StringUtils";
@@ -13,17 +12,12 @@ export interface TokenCardProps {
   uri: string;
   // Omit if this card shouldn't link anywhere
   link?: UrlObject;
-  height: number | string;
   width: number | string;
   outerBorderColor?: FrameColor;
   innerBorder?: boolean;
 }
 
 const TokenCard: React.FC<TokenCardProps> = (props: TokenCardProps) => {
-  const myLoader = ({ src, width, quality }) => {
-    return src;
-  };
-
   const getFrameBorder = (color: FrameColor) => {
     if (color === "Black") {
       return styles.blackFrame;
@@ -42,7 +36,7 @@ const TokenCard: React.FC<TokenCardProps> = (props: TokenCardProps) => {
 
   const content = (
     <a className={styles.card}>
-      <Image
+      <img
         className={classNames(
           styles.image,
           hasBorder ? styles.imageRadius : null,
@@ -51,8 +45,6 @@ const TokenCard: React.FC<TokenCardProps> = (props: TokenCardProps) => {
         )}
         src={props.uri}
         alt={props.name}
-        loader={myLoader}
-        height={props.height}
         width={props.width}
       />
     </a>

--- a/src/components/TokenGrid.tsx
+++ b/src/components/TokenGrid.tsx
@@ -23,10 +23,14 @@ const TokenGrid: React.FC<TokenGridProps> = () => {
   useEffect(() => {
     setWindowWidth(window.innerWidth);
     setWindowHeight(window.innerHeight);
-    window.addEventListener("resize", (e) => {
+    const resizeListener = (_e: any) => {
       setWindowHeight(window.innerHeight);
       setWindowWidth(window.innerWidth);
-    });
+    };
+    window.addEventListener("resize", resizeListener);
+    return () => {
+      window.removeEventListener("resize", resizeListener);
+    };
   }, []);
 
   // If there are more items to be loaded then add an extra row to hold a loading indicator.
@@ -91,7 +95,6 @@ const TokenGrid: React.FC<TokenGridProps> = () => {
                       pathname: "/customize",
                       query: { index: String(index) },
                     }}
-                    height={(windowWidth * 0.2) / 0.7}
                     width={windowWidth * 0.2}
                   />
                 </div>

--- a/src/pages/checkout.tsx
+++ b/src/pages/checkout.tsx
@@ -77,7 +77,7 @@ export default function Review() {
       <main className={styles.main}>
         <div className={styles.cartTitleContainer}>
           <span className={classNames(styles.largeFont)}>
-            Checkout - Payment Details
+            Checkout - Payment
           </span>
         </div>
         {cart.length === 0 ? (

--- a/src/pages/customize.tsx
+++ b/src/pages/customize.tsx
@@ -102,6 +102,7 @@ export default function Customize(props: CustomizePageProps) {
                   disabled={!hasValidConfiguration(itemConfiguration)}
                   color="primary"
                   variant="outlined"
+                  size="large"
                   onClick={() => {
                     addToCart({
                       name: item.name,
@@ -117,14 +118,16 @@ export default function Customize(props: CustomizePageProps) {
                 </Button>
               </div>
             </div>
-            <TokenCard
-              key={item.id}
-              name={item.name}
-              uri={item.image_url}
-              width={500}
-              innerBorder={itemConfiguration.space === '3"'}
-              outerBorderColor={itemConfiguration.frame}
-            />
+            <div className={styles.customizeImageContainer}>
+              <TokenCard
+                key={item.id}
+                name={item.name}
+                uri={item.image_url}
+                width={500}
+                innerBorder={itemConfiguration.space === '3"'}
+                outerBorderColor={itemConfiguration.frame}
+              />
+            </div>
           </div>
         )}
       </main>

--- a/src/pages/customize.tsx
+++ b/src/pages/customize.tsx
@@ -10,8 +10,8 @@ import { OptionRow } from "../components/OptionRow";
 import classNames from "classnames";
 import { CartContext } from "../context/CartContext";
 import { ItemConfiguration } from "../hooks/useCart";
-import { ButtonSecondary } from '../components/Button'
-import styled from 'styled-components'
+import { ButtonSecondary } from "../components/Button";
+import styled from "styled-components";
 import { Button } from "@material-ui/core";
 
 interface CustomizePageProps {}
@@ -71,7 +71,6 @@ export default function Customize(props: CustomizePageProps) {
     <div className={styles.container}>
       <Header subPage="print" />
       <main className={styles.main}>
-
         {item == null ? (
           <section {...containerProps}>{indicatorEl}</section>
         ) : (
@@ -80,7 +79,7 @@ export default function Customize(props: CustomizePageProps) {
               <span
                 className={classNames(styles.largeFont, styles.customizeTitle)}
               >
-              <a className="siteTitleLink">{item.name}</a>
+                <a className="siteTitleLink">{item.name}</a>
               </span>
               {Object.keys(options).map((optionType) => {
                 return (
@@ -99,7 +98,8 @@ export default function Customize(props: CustomizePageProps) {
                 );
               })}
               <div className="cartDiv">
-                <Button disabled={!hasValidConfiguration(itemConfiguration)}
+                <Button
+                  disabled={!hasValidConfiguration(itemConfiguration)}
                   color="primary"
                   variant="outlined"
                   onClick={() => {
@@ -111,18 +111,16 @@ export default function Customize(props: CustomizePageProps) {
                       config: itemConfiguration,
                     });
                     router.push("/review");
-                  }} 
-                  href="/create/ETH">
+                  }}
+                >
                   Add to Cart
-                  </Button>
-                </div>
-
+                </Button>
+              </div>
             </div>
             <TokenCard
               key={item.id}
               name={item.name}
               uri={item.image_url}
-              height={715}
               width={500}
               innerBorder={itemConfiguration.space === '3"'}
               outerBorderColor={itemConfiguration.frame}

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -144,8 +144,13 @@
   display: flex;
   background-color: "#FFFFFe";
   border-radius: 20px;
-  box-shadow: 0 3.2px 8px 0 rgba(0, 0, 0, 0.132), 
-    0 0.6px 8px 0 rgba(0, 0, 0, 0.108)
+  box-shadow: 0 3.2px 8px 0 rgba(0, 0, 0, 0.132),
+    0 0.6px 8px 0 rgba(0, 0, 0, 0.108);
+}
+
+.customizeImageContainer {
+  padding-right: 2rem;
+  padding-top: 2rem;
 }
 
 .customizeTitle {

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -151,6 +151,7 @@
 .customizeImageContainer {
   padding-right: 2rem;
   padding-top: 2rem;
+  padding-bottom: 2rem;
 }
 
 .customizeTitle {


### PR DESCRIPTION
the main change here  is to switch from Next.js optimized image components back to the regular <img> HTML element. 

this allows us to specify the width without the height and retain the original aspect ratios.

i also added some padding to the customization screen to better accommodate these  different image sizes.