### PR TITLE
infinite loading fix

### DIFF
--- a/src/components/Header/HeaderActions.tsx
+++ b/src/components/Header/HeaderActions.tsx
@@ -16,7 +16,7 @@ interface HeaderActionsProps {
 function HeaderActions(props: HeaderActionsProps) {
   const { subPage, toggleWalletDropdown } = props;
   const { cart } = useContext(CartContext);
-  const { account } = useWeb3React();
+  const { account, active } = useWeb3React();
 
   const formatAddress: (address: string) => string = (address) => {
     return address.slice(0, 6) + "..." + address.slice(address.length - 4);
@@ -52,7 +52,7 @@ function HeaderActions(props: HeaderActionsProps) {
       <div className="flexStretch" />
 
       <div className="navPadding">
-        {account ? (
+        {account && active ? (
           <Button
             onClick={toggleWalletDropdown}
             color="primary"

--- a/src/components/TokenGrid.tsx
+++ b/src/components/TokenGrid.tsx
@@ -48,7 +48,7 @@ const TokenGrid: React.FC<TokenGridProps> = () => {
 
   return (
     <div className={"main"}>
-      {loading ? (
+      {loading && assets.length === 0 ? (
         <div style={{ marginTop: "5rem" }}>
           <section {...containerProps}>{indicatorEl}</section>
         </div>
@@ -107,6 +107,11 @@ const TokenGrid: React.FC<TokenGridProps> = () => {
           </Grid>
         )}
       </InfiniteLoader>
+      {loading && assets.length > 0 ? (
+        <div style={{ marginTop: "5rem" }}>
+          <section {...containerProps}>{indicatorEl}</section>
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/context/AssetsContextProvider.tsx
+++ b/src/context/AssetsContextProvider.tsx
@@ -8,9 +8,9 @@ export interface AssetsContextProviderProps {}
 const AssetsContextProvider: React.FC<
   PropsWithChildren<AssetsContextProviderProps>
 > = (props: PropsWithChildren<AssetsContextProviderProps>) => {
-  const { account } = useWeb3React();
+  const { account, active } = useWeb3React();
 
-  const assetsConfig: AssetsConfig = useAssets(account);
+  const assetsConfig: AssetsConfig = useAssets(account, active);
 
   return (
     <AssetsContext.Provider value={assetsConfig}>

--- a/src/hooks/useAssets.tsx
+++ b/src/hooks/useAssets.tsx
@@ -84,7 +84,10 @@ export type Asset = {
   top_bid: any;
 };
 
-const useAssets: (address: string) => AssetsConfig = (address: string) => {
+const useAssets: (address: string, active: boolean) => AssetsConfig = (
+  address: string,
+  active: boolean
+) => {
   const initialPageSize = 20;
 
   const options = {
@@ -153,7 +156,7 @@ const useAssets: (address: string) => AssetsConfig = (address: string) => {
   );
 
   useEffect(() => {
-    if (isNullOrEmpty(address)) {
+    if (isNullOrEmpty(address) || !active) {
       setAssets([]);
       setDidInitialFetch(false);
       return;
@@ -167,7 +170,7 @@ const useAssets: (address: string) => AssetsConfig = (address: string) => {
       );
       setDidInitialFetch(true);
     }
-  }, [address]);
+  }, [address, active]);
 
   const loadMore = useCallback(
     async (startIndex: number, endIndex: number) => {


### PR DESCRIPTION
i think a `useWeb3React` quirk was causing this bug? sometimes when first loading the page, it will return an address but won't be "active". so we were doing our initial fetch too early, before the user has actually connected their web3 account via the UI.


now, we check the "active" bool in both the header and the useAssets hook which seems to prevent the initial fetch from happening until the user logs in